### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/intellij-maven/10/10.5.4/pom.xml
+++ b/intellij-maven/10/10.5.4/pom.xml
@@ -641,7 +641,7 @@
       <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
       </dependency>
       <dependency>
         <groupId>commons-httpclient</groupId>

--- a/intellij-maven/11/11.1.4/pom.xml
+++ b/intellij-maven/11/11.1.4/pom.xml
@@ -777,7 +777,7 @@
       <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
       </dependency>
       <dependency>
         <groupId>commons-httpclient</groupId>

--- a/intellij-maven/12/12.0.0/pom.xml
+++ b/intellij-maven/12/12.0.0/pom.xml
@@ -931,7 +931,7 @@
       <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
       </dependency>
       <dependency>
         <groupId>commons-httpclient</groupId>

--- a/intellij-maven/9/9.0.4/pom.xml
+++ b/intellij-maven/9/9.0.4/pom.xml
@@ -640,7 +640,7 @@
       <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
       </dependency>
       <dependency>
         <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
